### PR TITLE
今のうちに QUnit 2.0 のやり方にそろえておく

### DIFF
--- a/MIT-LICENSE.txt
+++ b/MIT-LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2013 TDD BaseCamp and other contributors
+Copyright 2013-2015 TDD BaseCamp and other contributors
 http://devtesting.jp/tddbc/
 https://github.com/tddbc
 

--- a/tests.js
+++ b/tests.js
@@ -1,7 +1,7 @@
-module("QUnit の使い方");
+QUnit.module("QUnit の使い方");
 
 
-test( "assert.ok の使い方", function(assert) {
+QUnit.test( "assert.ok の使い方", function(assert) {
   var truth = true;
   assert.ok(truth, "assert.ok は引数が truthy であるかどうかを検証します");
 
@@ -12,20 +12,20 @@ test( "assert.ok の使い方", function(assert) {
 
 // QUnit の assert.equal 系は引数の順番が actual, expected の順(JUnit の逆)なので注意してください
 
-test( "equal, notEqual の使い方", function(assert) {
+QUnit.test( "equal, notEqual の使い方", function(assert) {
   assert.equal('hoge', 'hoge');
   assert.equal(1, '1', 'equal は == を使います');
   assert.notEqual('foo', 'bar');
 });
 
 
-test( "strictEqual, notStrictEqual の使い方", function(assert) {
+QUnit.test( "strictEqual, notStrictEqual の使い方", function(assert) {
   assert.strictEqual('1', '1');
   assert.notStrictEqual(1, '1', 'strictEqual は === を使います');
 });
 
 
-test( "deepEqual, notDeepEqual の使い方", function(assert) {
+QUnit.test( "deepEqual, notDeepEqual の使い方", function(assert) {
   var ary = ['foo', 'bar'];
   assert.deepEqual(ary.map(function(str){return str.toUpperCase();}), ['FOO', 'BAR'], 'Array の比較を行えます');
 
@@ -38,7 +38,7 @@ test( "deepEqual, notDeepEqual の使い方", function(assert) {
 });
 
 
-test( "例外のテストの書き方", function(assert) {
+QUnit.test( "例外のテストの書き方", function(assert) {
   assert.throws(function () {
       throw new Error('例外');
   }, 'throws で例外が投げられることをテストできます');


### PR DESCRIPTION
QUnit 2.0 でグローバルに公開される関数が減るので、今のうちに 2.0 のやり方にそろえておきます (1.16, 1.17 は 2.0 移行のためのバージョンです)

see also:
- http://blog.jquery.com/2014/12/10/qunit-1-16-release-and-roadmap/
- http://qunitjs.com/upgrade-guide-2.x/